### PR TITLE
Fix buggy logic

### DIFF
--- a/backend/room/room_services.go
+++ b/backend/room/room_services.go
@@ -60,7 +60,6 @@ func (s *Service) generateRoomCodeLocked() int {
 			break
 		}
 	}
-	s.max = s.max - 1
 	return code
 }
 


### PR DESCRIPTION
Maximum room number was decremented every time a room was created. 
This was unnecessary, and led to a smaller effective number of rooms that could be created.
Relevant logic has been removed.