### PR TITLE
Move placeholder data for cards into backend

### DIFF
--- a/backend/handlers/room_http.go
+++ b/backend/handlers/room_http.go
@@ -118,3 +118,69 @@ func parseRoomCode(req *http.Request) (string, error) {
 
 	return roomCode, nil
 }
+
+func (s *Server) HandleGetCardData(w http.ResponseWriter, req *http.Request) {
+	cards := []util.Card{
+		{
+			ID: "1",
+			Title: "Sushi Express",
+			Description: "Affordable conveyor-belt sushi chain popular for $2++ plates and a wide variety of Japanese dishes.",
+		},
+		{
+			ID: "2",
+			Title: "Eighteen Chefs",
+			Description: "Casual Western-fusion restaurant famous for its 'Heart Attack Fried Rice' and hearty mains.",
+		},
+		{
+			ID: "3",
+			Title: "Seoul Garden",
+			Description: "Korean BBQ buffet restaurant offering grill-it-yourself meats and hotpot options.",
+		},
+		{
+			ID: "4",
+			Title: "Ichiban Sushi",
+			Description: "Family-friendly Japanese restaurant serving sushi, ramen, donburi and bento sets.",
+		},
+		{
+			ID: "5",
+			Title: "Swensen's",
+			Description: "Classic Western restaurant known for fish & chips, burgers and ice cream desserts.",
+		},
+		{
+			ID: "6",
+			Title: "Pho Vietnam",
+			Description: "Vietnamese restaurant serving pho noodle soups, banh mi and other traditional dishes.",
+		},
+		{
+			ID: "7",
+			Title: "Yakiniku Like",
+			Description: "Japanese solo BBQ restaurant where diners grill individual meat sets quickly at their table.",
+		},
+		{
+			ID: "8",
+			Title: "Soup Restaurant",
+			Description: "Singapore brand famous for its Samsui Ginger Chicken and traditional Chinese home-style dishes.",
+		},
+		{
+			ID: "9",
+			Title: "Kenny Rogers Roasters Express",
+			Description: "Western chain known for roasted chicken, ribs, and hearty comfort-food sides.",
+		},
+		{
+			ID: "10",
+			Title: "Munchi Pancakes",
+			Description: "Local snack stall selling traditional min jiang kueh pancakes with sweet fillings.",
+		},
+	}
+
+	m := util.Message{
+		Header: "CARD_DATA",
+		Cards:  cards,
+	}
+
+	if err := json.NewEncoder(w).Encode(m); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+	

--- a/backend/main.go
+++ b/backend/main.go
@@ -28,6 +28,7 @@ func main() {
 	mux.HandleFunc("/get-room-code", s.GetRoomCode)
 	mux.HandleFunc("/join-room", s.HandleRoomJoin)
 	mux.HandleFunc("/start-room", s.HandleRoomStart)
+	mux.HandleFunc("/get-card-data", s.HandleGetCardData)
 
 	// WebSocket endpoint (CORS isn’t enforced the same way for WS, but it’s fine to wrap anyway)
 	mux.HandleFunc("/ws", s.HandleRoomWS)

--- a/backend/util/message.go
+++ b/backend/util/message.go
@@ -5,8 +5,15 @@ type Vote struct {
 	Result string
 }
 
+type Card struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
 type Message struct {
 	Header  string  `json:"Header"`
 	Body    *string `json:"Body,omitempty"`
 	VoteObj *Vote   `json:"VoteObj,omitempty"`
+	Cards   []Card  `json:"Cards,omitempty"`
 }

--- a/frontend/app/swipe/index.tsx
+++ b/frontend/app/swipe/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { View, Text, StyleSheet, useWindowDimensions } from "react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Card, SwipeDirection } from "../../src/swipe/types";
@@ -7,21 +7,29 @@ import { SwipeDeck } from "../../src/swipe/SwipeDeck";
 import { useLocalSearchParams } from "expo-router";
 import { useRoomWS } from "@/services/ws";
 import { Message } from "@/services/types";
+import { getCardData } from "@/services/api/http";
 
 export default function SwipeScreen() {
+  const [data, setData] = useState<Card[]>([]);
   const { width, height } = useWindowDimensions();
   const { roomCode } = useLocalSearchParams<{ roomCode: string }>();
   const ws = useRoomWS(roomCode);
 
-  const data = useMemo<Card[]>(
-    () =>
-      Array.from({ length: 10 }, (_, i) => ({
-        id: String(i + 1),
-        title: `Place ${i + 1}`,
-        description: "Placeholder description. Swipe right to accept, left to reject.",
-      })),
-    []
-  );
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const location = "PLACEHOLDER_LOCATION";
+      const res = await getCardData(location);
+      if (!cancelled) setData(res || []);
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleSwipe = useCallback((card: Card, direction: SwipeDirection) => {
     let result = direction === "right" ? "ACCEPT" : "REJECT"

--- a/frontend/services/api/http.ts
+++ b/frontend/services/api/http.ts
@@ -1,17 +1,23 @@
 import { api } from "./client";
 import { Message } from "../types"
+import { Card } from "@/src/swipe/types";
 
-export async function getRoomCode(): Promise<string> {
+export async function getRoomCode(): Promise<string | undefined> {
   const res = await api.get<Message>("/get-room-code");
   return res.Body;
 }
 
-export async function joinRoom(roomCode: number): Promise<string> {
+export async function joinRoom(roomCode: number): Promise<string | undefined> {
   const res = await api.post<Message>("/join-room", roomCode.toString());
-  return res.Body.toLowerCase();
+  return res.Body?.toLowerCase();
 }
 
-export async function startRoom(roomCode: string): Promise<string> {
+export async function startRoom(roomCode: string): Promise<string | undefined> {
   const res = await api.post<Message>("/start-room", roomCode);
-  return res.Body.toLowerCase();
+  return res.Body?.toLowerCase();
+}
+
+export async function getCardData(location: string): Promise<Card[] | undefined> {
+  const res = await api.post<Message>("/get-card-data", location);
+  return res.Cards;
 }

--- a/frontend/services/types.ts
+++ b/frontend/services/types.ts
@@ -1,7 +1,10 @@
+import { Card } from "@/src/swipe/types";
+
 export type Message = {
   Header: string;
   Body?: string;
   VoteObj?: Vote
+  Cards?: Card[]
 };
 
 type Vote = {


### PR DESCRIPTION
**Frontend Changes**
- Removed locally generated placeholder cards (Array.from).
- Added API call using getCardData(location) to fetch cards from the backend.
- Implemented useEffect to fetch card data once when SwipeScreen mounts.
- Parsed backend response and populated useState<Card[]>.

**Backend Changes**
- Added Cards []Card field to the Message struct to support sending swipe card data.
- Implemented HandleGetCardData handler to return placeholder cards.
- Added 10 placeholder restaurant cards (Clementi Mall restaurants).
- Response format:

```
{
  "Header": "CARD_DATA",
  "Cards": [...]
}
```