### PR TITLE
Bug fix for cors error and websocket error

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,6 +1,10 @@
 events { worker_connections 1024; }
 
 http {
+    # Include standard mime types so browsers don't block CSS/JS/JSON layouts
+    include       /etc/nginx/mime.types;
+    default_type  application/json;
+
     upstream go_servers {
         server app-instance-1:8090;
         server app-instance-2:8090;
@@ -10,25 +14,20 @@ http {
         listen 80;
 
         location / {
-            # Allows Vercel to fetch data from your backend
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
-            add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, X-Requested-With' always;
+            # --- CRITICAL NGROK BYPASS ---
+            proxy_set_header ngrok-skip-browser-warning "true";
 
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*' always;
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE' always;
-                add_header 'Access-Control-Allow-Headers' 'Authorization, Content-Type, X-Requested-With' always;
-                add_header 'Content-Length' 0;
-                add_header 'Content-Type' 'text/plain; charset=utf-8';
-                return 204;
-            }
-
+            # --- PROXY HEADERS ---
             proxy_pass http://go_servers;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+	    # --- Add support for ws ---
+	    proxy_http_version 1.1;
+    	    proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
         }
     }
 }


### PR DESCRIPTION
### 1. Unified CORS Management (Removed Duplication)

* **Problem:** Both Nginx and the Go application (`github.com/rs/cors`) were appending `Access-Control-Allow-Origin` response headers. This duplicate implementation confused browsers during cross-origin preflight requests, causing them to drop payloads despite a `200 OK` network status.
* **Solution:** Stripped all hardcoded CORS header injections and preflight `OPTIONS` short-circuits out of `nginx.conf`. CORS policies are now safely managed downstream dynamically by our Go framework layer.

### 2. Enabled WebSocket Proxy Handshaking (`/ws`)

* **Problem:** Upstream persistent WebSocket connections were failing with a `400 Bad Request` because Nginx was dropping connection adjustment targets during standard reverse proxy passes.
* **Solution:** Configured Nginx to properly translate hop-by-hop HTTP upgrade paths. Added:
* `proxy_http_version 1.1;`
* `proxy_set_header Upgrade $http_upgrade;`
* `proxy_set_header Connection "Upgrade";`



### 3. Integrated Ngrok Interception Bypass

* **Problem:** Free-tier Ngrok instances intercept raw automated requests with an HTML warning splash page, breaking frontend JSON parsers.
* **Solution:** Added a permanent `ngrok-skip-browser-warning: "true"` injection header onto the proxy routing pipeline to seamlessly stream data payloads directly to Vercel.

### 4. Mime Type Integrity

* **Refactor:** Included standard systems layout maps (`/etc/nginx/mime.types`) and established `application/json` as the fallback format to ensure modern browsers don't experience asset loading blocks.